### PR TITLE
Move to Minitest 5

### DIFF
--- a/introspection.gemspec
+++ b/introspection.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "metaclass", "~> 0.0.1"
   s.add_dependency "instantiator", "~> 0.0.3"
 
+  s.add_development_dependency "minitest", "~> 5.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "blankslate"
 end

--- a/test/class_snapshot_test.rb
+++ b/test/class_snapshot_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ClassSnapshotTest < Test::Unit::TestCase
+class ClassSnapshotTest < Minitest::Test
 
   def test_detect_class_method_on_class
     for_all_method_visibilities do |visibility|

--- a/test/instance_snapshot_test.rb
+++ b/test/instance_snapshot_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class InstanceSnapshotTest < Test::Unit::TestCase
+class InstanceSnapshotTest < Minitest::Test
 
   def test_detect_instance_method_on_singleton_class
     for_all_method_visibilities do |visibility|

--- a/test/module_snapshot_test.rb
+++ b/test/module_snapshot_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ModuleSnapshotTest < Test::Unit::TestCase
+class ModuleSnapshotTest < Minitest::Test
 
   def test_detect_module_method_on_module
     for_all_method_visibilities do |visibility|

--- a/test/snapshot_test.rb
+++ b/test/snapshot_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "blankslate"
 
-class SnapshotTest < Test::Unit::TestCase
+class SnapshotTest < Minitest::Test
 
   include Introspection
 
@@ -49,7 +49,8 @@ class SnapshotTest < Test::Unit::TestCase
   end
 
   def test_should_cope_with_blankslate_object
-    assert_nothing_raised { Snapshot.new(BlankSlate.new) }
+    # Should not raise anything
+    Snapshot.new(BlankSlate.new)
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require "rubygems"
 require "bundler/setup"
 
 require "introspection"
-require "test/unit"
+require "minitest/autorun"
 
 module Introspection
   module TestHelper
@@ -23,7 +23,7 @@ module Introspection
   end
 end
 
-class Test::Unit::TestCase
+class Minitest::Test
   include Introspection::TestHelper
   include Introspection::LocalAssertions
   include Introspection::Assertions


### PR DESCRIPTION
Upgrade test suite to Minitest 5 as `test/unit` is not part of Ruby anymore.