### PR TITLE
Add ruby-2.4 and ruby-head in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 before_install:
   - gem install bundler
 rvm:
-  - 1.8
   - 1.9
   - 2.0
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
+  - 2.4.0
+  - ruby-head
   - jruby-9.1.5.0
   - rbx-3.9
 matrix:
   allow_failures:
+  - rvm: ruby-head
   - rvm: rbx-3.9
+  fast_finish: true


### PR DESCRIPTION
I want to add ruby-2.4 and ruby-head in `.travis.yml`.

## Ruby 2.4

I added "2.4.0", not "2.4".
Because last month I tried "2.4" in `.travis.yml`, it was not available.
I can not find official document for that.

## ruby-head

I want to add `ruby-head` as allow_failures in `.travis.yml`.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
I think that is the reason why `rails` and `rspec` can support new version Ruby as faster.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to add it?

Thanks.

